### PR TITLE
Fix conflicting outside corner recipes

### DIFF
--- a/asphault.lua
+++ b/asphault.lua
@@ -235,9 +235,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "myroofs:asphalt_shingle_"..color.."_ocorner 3",
 	recipe = {
-		{"", "",""},
-		{"", "myroofs:asphalt_shingle_"..color.."_bundle",""},
-		{"", "myroofs:asphalt_shingle_"..color.."_bundle","myroofs:asphalt_shingle_"..color.."_bundle"},
+		{"", "", ""},
+		{"", "myroofs:asphalt_shingle_"..color.."_bundle", ""},
+		{"myroofs:asphalt_shingle_"..color.."_bundle", "", "myroofs:asphalt_shingle_"..color.."_bundle"},
 	}
 })
 end

--- a/homedecor.lua
+++ b/homedecor.lua
@@ -237,9 +237,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "myroofs:asphalt_shingle_"..color.."_ocorner 3",
 	recipe = {
-		{"", "",""},
-		{"", item,""},
-		{"", item,item},
+		{"", "", ""},
+		{"", item, ""},
+		{item, "", item},
 	}
 })
 end

--- a/straw.lua
+++ b/straw.lua
@@ -199,9 +199,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "myroofs:"..color.."_roof_ocorner 5",
 	recipe = {
-		{"", "",""},
-		{"",item,""},
-		{"",item,item},
+		{"", "", ""},
+		{"", item, ""},
+		{item, "", item},
 	}
 })
 


### PR DESCRIPTION
Changes recipes for 'outside corners' so that they do not conflict with 'inside corner' recipes.

Note: Recipes for straw roofing conflict with *[castle_farming](https://github.com/minetest-mods/castle_farming)*.